### PR TITLE
bug: dont use total_increasing for power

### DIFF
--- a/src/model/mqtt.php
+++ b/src/model/mqtt.php
@@ -42,11 +42,6 @@ class mqtt extends json {
         break;
       case 'kW':
         $dev_cla = 'power';
-        switch($option_name){
-          case 'todayYield':
-            $state_cla = 'total_increasing';
-            break;
-        }
         break;
       case 'kWh':
         $dev_cla = 'energy';


### PR DESCRIPTION
fix an error from HA

```
Entity sensor.foxesscloud_661f502012ec099_todayyield (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using state class 'total_increasing' which is impossible considering device class ('power') it is using; expected None or one of 'measurement'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```